### PR TITLE
Adds H1_2 humanoid robot configurations and retargeters

### DIFF
--- a/scripts/environments/teleoperation/teleop_h1_2_agent.py
+++ b/scripts/environments/teleoperation/teleop_h1_2_agent.py
@@ -1,0 +1,264 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Script to run a keyboard teleoperation with Isaac Lab manipulation environments for H1_2 robot."""
+
+"""Launch Isaac Sim Simulator first."""
+
+import argparse
+from collections.abc import Callable
+
+from isaaclab.app import AppLauncher
+
+# add argparse arguments
+parser = argparse.ArgumentParser(description="Keyboard teleoperation for Isaac Lab H1_2 environments.")
+parser.add_argument("--num_envs", type=int, default=1, help="Number of environments to simulate.")
+parser.add_argument(
+    "--teleop_device",
+    type=str,
+    default="keyboard",
+    choices=["keyboard", "spacemouse", "gamepad", "handtracking"],
+    help="Device for interacting with environment",
+)
+parser.add_argument("--task", type=str, default="Isaac-PickPlace-H1_2-Abs-v0", help="Name of the task.")
+parser.add_argument("--sensitivity", type=float, default=1.0, help="Sensitivity factor.")
+parser.add_argument(
+    "--enable_pinocchio",
+    action="store_true",
+    default=False,
+    help="Enable Pinocchio.",
+)
+# append AppLauncher cli args
+AppLauncher.add_app_launcher_args(parser)
+# parse the arguments
+args_cli = parser.parse_args()
+
+app_launcher_args = vars(args_cli)
+
+if args_cli.enable_pinocchio:
+    # Import pinocchio before AppLauncher to force the use of the version installed by IsaacLab and
+    # not the one installed by Isaac Sim pinocchio is required by the Pink IK controllers and the
+    # H1_2 retargeter
+    import pinocchio  # noqa: F401
+if "handtracking" in args_cli.teleop_device.lower():
+    app_launcher_args["xr"] = True
+
+# launch omniverse app
+app_launcher = AppLauncher(app_launcher_args)
+simulation_app = app_launcher.app
+
+"""Rest everything follows."""
+
+
+import gymnasium as gym
+import torch
+
+import omni.log
+
+from isaaclab.devices import Se3Gamepad, Se3GamepadCfg, Se3Keyboard, Se3KeyboardCfg, Se3SpaceMouse, Se3SpaceMouseCfg
+from isaaclab.devices.openxr import remove_camera_configs
+from isaaclab.devices.teleop_device_factory import create_teleop_device
+from isaaclab.managers import TerminationTermCfg as DoneTerm
+
+import isaaclab_tasks  # noqa: F401
+from isaaclab_tasks.manager_based.manipulation.lift import mdp
+from isaaclab_tasks.utils import parse_env_cfg
+
+if args_cli.enable_pinocchio:
+    import isaaclab_tasks.manager_based.manipulation.pick_place  # noqa: F401
+
+
+def main() -> None:
+    """
+    Run keyboard teleoperation with Isaac Lab H1_2 manipulation environment.
+
+    Creates the environment, sets up teleoperation interfaces and callbacks,
+    and runs the main simulation loop until the application is closed.
+
+    Returns:
+        None
+    """
+    # parse configuration
+    env_cfg = parse_env_cfg(args_cli.task, device=args_cli.device, num_envs=args_cli.num_envs)
+    env_cfg.env_name = args_cli.task
+    # modify configuration
+    env_cfg.terminations.time_out = None
+    if "PickPlace" in args_cli.task:
+        # set the resampling time range to large number to avoid resampling
+        env_cfg.commands.object_pose.resampling_time_range = (1.0e9, 1.0e9)
+        # add termination condition for reaching the goal otherwise the environment won't reset
+        env_cfg.terminations.object_reached_goal = DoneTerm(func=mdp.object_reached_goal)
+
+    if args_cli.xr:
+        # External cameras are not supported with XR teleop
+        # Check for any camera configs and disable them
+        env_cfg = remove_camera_configs(env_cfg)
+        env_cfg.sim.render.antialiasing_mode = "DLSS"
+
+    try:
+        # create environment
+        env = gym.make(args_cli.task, cfg=env_cfg).unwrapped
+        # check environment name (for reach , we don't allow the gripper)
+        if "Reach" in args_cli.task:
+            omni.log.warn(
+                f"The environment '{args_cli.task}' does not support gripper control. The device command will be"
+                " ignored."
+            )
+    except Exception as e:
+        omni.log.error(f"Failed to create environment: {e}")
+        simulation_app.close()
+        return
+
+    # Flags for controlling teleoperation flow
+    should_reset_recording_instance = False
+    teleoperation_active = True
+
+    # Callback handlers
+    def reset_recording_instance() -> None:
+        """
+        Reset the environment to its initial state.
+
+        Sets a flag to reset the environment on the next simulation step.
+
+        Returns:
+            None
+        """
+        nonlocal should_reset_recording_instance
+        should_reset_recording_instance = True
+        print("Reset triggered - Environment will reset on next step")
+
+    def start_teleoperation() -> None:
+        """
+        Activate teleoperation control of the robot.
+
+        Enables the application of teleoperation commands to the environment.
+
+        Returns:
+            None
+        """
+        nonlocal teleoperation_active
+        teleoperation_active = True
+        print("Teleoperation activated")
+
+    def stop_teleoperation() -> None:
+        """
+        Deactivate teleoperation control of the robot.
+
+        Disables the application of teleoperation commands to the environment.
+
+        Returns:
+            None
+        """
+        nonlocal teleoperation_active
+        teleoperation_active = False
+        print("Teleoperation deactivated")
+
+    # Create device config if not already in env_cfg
+    teleoperation_callbacks: dict[str, Callable[[], None]] = {
+        "R": reset_recording_instance,
+        "START": start_teleoperation,
+        "STOP": stop_teleoperation,
+        "RESET": reset_recording_instance,
+    }
+
+    # For hand tracking devices, add additional callbacks
+    if args_cli.xr:
+        # Default to inactive for hand tracking
+        teleoperation_active = False
+    else:
+        # Always active for other devices
+        teleoperation_active = True
+
+    # Create teleop device from config if present, otherwise create manually
+    teleop_interface = None
+    try:
+        if hasattr(env_cfg, "teleop_devices") and args_cli.teleop_device in env_cfg.teleop_devices.devices:
+            teleop_interface = create_teleop_device(
+                args_cli.teleop_device, env_cfg.teleop_devices.devices, teleoperation_callbacks
+            )
+        else:
+            omni.log.warn(f"No teleop device '{args_cli.teleop_device}' found in environment config. Creating default.")
+            # Create fallback teleop device
+            sensitivity = args_cli.sensitivity
+            if args_cli.teleop_device.lower() == "keyboard":
+                teleop_interface = Se3Keyboard(
+                    Se3KeyboardCfg(pos_sensitivity=0.05 * sensitivity, rot_sensitivity=0.05 * sensitivity)
+                )
+            elif args_cli.teleop_device.lower() == "spacemouse":
+                teleop_interface = Se3SpaceMouse(
+                    Se3SpaceMouseCfg(pos_sensitivity=0.05 * sensitivity, rot_sensitivity=0.05 * sensitivity)
+                )
+            elif args_cli.teleop_device.lower() == "gamepad":
+                teleop_interface = Se3Gamepad(
+                    Se3GamepadCfg(pos_sensitivity=0.1 * sensitivity, rot_sensitivity=0.1 * sensitivity)
+                )
+            else:
+                omni.log.error(f"Unsupported teleop device: {args_cli.teleop_device}")
+                omni.log.error("Supported devices: keyboard, spacemouse, gamepad, handtracking")
+                env.close()
+                simulation_app.close()
+                return
+
+            # Add callbacks to fallback device
+            for key, callback in teleoperation_callbacks.items():
+                try:
+                    teleop_interface.add_callback(key, callback)
+                except (ValueError, TypeError) as e:
+                    omni.log.warn(f"Failed to add callback for key {key}: {e}")
+    except Exception as e:
+        omni.log.error(f"Failed to create teleop device: {e}")
+        env.close()
+        simulation_app.close()
+        return
+
+    if teleop_interface is None:
+        omni.log.error("Failed to create teleop interface")
+        env.close()
+        simulation_app.close()
+        return
+
+    print(f"Using teleop device: {teleop_interface}")
+
+    # reset environment
+    env.reset()
+    teleop_interface.reset()
+
+    print("Teleoperation started. Press 'R' to reset the environment.")
+
+    # simulate environment
+    while simulation_app.is_running():
+        try:
+            # run everything in inference mode
+            with torch.inference_mode():
+                # get device command
+                action = teleop_interface.advance()
+
+                # Only apply teleop commands when active
+                if teleoperation_active:
+                    # process actions
+                    actions = action.repeat(env.num_envs, 1)
+                    # apply actions
+                    env.step(actions)
+                else:
+                    env.sim.render()
+
+                if should_reset_recording_instance:
+                    env.reset()
+                    should_reset_recording_instance = False
+                    print("Environment reset complete")
+        except Exception as e:
+            omni.log.error(f"Error during simulation step: {e}")
+            break
+
+    # close the simulator
+    env.close()
+    print("Environment closed")
+
+
+if __name__ == "__main__":
+    # run the main function
+    main()
+    # close sim app
+    simulation_app.close()

--- a/source/isaaclab/isaaclab/devices/openxr/retargeters/__init__.py
+++ b/source/isaaclab/isaaclab/devices/openxr/retargeters/__init__.py
@@ -5,6 +5,7 @@
 """Retargeters for mapping input device data to robot commands."""
 
 from .humanoid.fourier.gr1t2_retargeter import GR1T2Retargeter, GR1T2RetargeterCfg
+from .humanoid.unitree.h1_2_retargeter import H1_2Retargeter, H1_2RetargeterCfg
 from .manipulator.gripper_retargeter import GripperRetargeter, GripperRetargeterCfg
 from .manipulator.se3_abs_retargeter import Se3AbsRetargeter, Se3AbsRetargeterCfg
 from .manipulator.se3_rel_retargeter import Se3RelRetargeter, Se3RelRetargeterCfg

--- a/source/isaaclab/isaaclab/devices/openxr/retargeters/humanoid/unitree/__init__.py
+++ b/source/isaaclab/isaaclab/devices/openxr/retargeters/humanoid/unitree/__init__.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Unitree robot retargeters for OpenXR hand tracking."""
+
+from .h1_2_retargeter import H1_2Retargeter, H1_2RetargeterCfg
+
+__all__ = ["H1_2Retargeter", "H1_2RetargeterCfg"]

--- a/source/isaaclab/isaaclab/devices/openxr/retargeters/humanoid/unitree/h1_2_retargeter.py
+++ b/source/isaaclab/isaaclab/devices/openxr/retargeters/humanoid/unitree/h1_2_retargeter.py
@@ -1,0 +1,258 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import numpy as np
+import torch
+from dataclasses import dataclass
+
+import isaaclab.sim as sim_utils
+import isaaclab.utils.math as PoseUtils
+from isaaclab.devices import OpenXRDevice
+from isaaclab.devices.retargeter_base import RetargeterBase, RetargeterCfg
+from isaaclab.markers import VisualizationMarkers, VisualizationMarkersCfg
+
+
+@dataclass
+class H1_2RetargeterCfg(RetargeterCfg):
+    """Configuration for the H1_2 retargeter."""
+
+    enable_visualization: bool = False
+    num_open_xr_hand_joints: int = 100
+    hand_joint_names: list[str] | None = None  # List of robot hand joint names
+    arm_joint_names: list[str] | None = None  # List of robot arm joint names
+
+
+class H1_2Retargeter(RetargeterBase):
+    """Retargets OpenXR hand tracking data to H1_2 hand and arm end-effector commands.
+
+    This retargeter maps hand tracking data from OpenXR to joint commands for the H1_2 robot's hands and arms.
+    It handles both left and right hands, converting poses to joint angles for the H1_2 robot.
+    """
+
+    def __init__(
+        self,
+        cfg: H1_2RetargeterCfg,
+    ):
+        """Initialize the H1_2 hand retargeter.
+
+        Args:
+            cfg: Configuration object containing retargeter settings
+        """
+        super().__init__(cfg)
+        
+        self._hand_joint_names = cfg.hand_joint_names or []
+        self._arm_joint_names = cfg.arm_joint_names or []
+        
+        # Initialize visualization if enabled
+        self._enable_visualization = cfg.enable_visualization
+        self._num_open_xr_hand_joints = cfg.num_open_xr_hand_joints
+        self._sim_device = cfg.sim_device
+        
+        if self._enable_visualization:
+            marker_cfg = VisualizationMarkersCfg(
+                prim_path="/Visuals/markers",
+                markers={
+                    "joint": sim_utils.SphereCfg(
+                        radius=0.005,
+                        visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 1.0, 0.0)),
+                    ),
+                },
+            )
+            self._markers = VisualizationMarkers(marker_cfg)
+
+    def retarget(self, data: dict) -> torch.Tensor:
+        """Convert hand joint poses to robot end-effector commands.
+
+        Args:
+            data: Dictionary mapping tracking targets to joint data dictionaries.
+
+        Returns:
+            torch.Tensor: Concatenated tensor containing:
+                - Left wrist pose (7 values: x, y, z, qx, qy, qz, qw)
+                - Right wrist pose (7 values: x, y, z, qx, qy, qz, qw)
+                - Left hand joint angles (variable length based on hand_joint_names)
+                - Right hand joint angles (variable length based on hand_joint_names)
+                - Left arm joint angles (variable length based on arm_joint_names)
+                - Right arm joint angles (variable length based on arm_joint_names)
+        """
+
+        # Access the left and right hand data using the enum key
+        left_hand_poses = data[OpenXRDevice.TrackingTarget.HAND_LEFT]
+        right_hand_poses = data[OpenXRDevice.TrackingTarget.HAND_RIGHT]
+
+        left_wrist = left_hand_poses.get("wrist")
+        right_wrist = right_hand_poses.get("wrist")
+
+        if self._enable_visualization:
+            joints_position = np.zeros((self._num_open_xr_hand_joints, 3))
+
+            joints_position[::2] = np.array([pose[:3] for pose in left_hand_poses.values()])
+            joints_position[1::2] = np.array([pose[:3] for pose in right_hand_poses.values()])
+
+            self._markers.visualize(translations=torch.tensor(joints_position, device=self._sim_device))
+
+        # Process hand joint angles
+        left_hand_joints = self._process_hand_joints(left_hand_poses, "left")
+        right_hand_joints = self._process_hand_joints(right_hand_poses, "right")
+        
+        # Process arm joint angles (simplified IK for arm positioning)
+        left_arm_joints = self._process_arm_joints(left_wrist, "left")
+        right_arm_joints = self._process_arm_joints(right_wrist, "right")
+
+        # Convert numpy arrays to tensors and concatenate them
+        left_wrist_tensor = torch.tensor(left_wrist, dtype=torch.float32, device=self._sim_device)
+        right_wrist_tensor = torch.tensor(self._retarget_abs(right_wrist), dtype=torch.float32, device=self._sim_device)
+        left_hand_tensor = torch.tensor(left_hand_joints, dtype=torch.float32, device=self._sim_device)
+        right_hand_tensor = torch.tensor(right_hand_joints, dtype=torch.float32, device=self._sim_device)
+        left_arm_tensor = torch.tensor(left_arm_joints, dtype=torch.float32, device=self._sim_device)
+        right_arm_tensor = torch.tensor(right_arm_joints, dtype=torch.float32, device=self._sim_device)
+
+        # Combine all tensors into a single tensor
+        return torch.cat([
+            left_wrist_tensor, 
+            right_wrist_tensor, 
+            left_hand_tensor, 
+            right_hand_tensor,
+            left_arm_tensor,
+            right_arm_tensor
+        ])
+
+    def _process_hand_joints(self, hand_poses: dict, hand_side: str) -> np.ndarray:
+        """Process hand joint poses to generate joint angles.
+        
+        Args:
+            hand_poses: Dictionary of hand joint poses from OpenXR
+            hand_side: "left" or "right" to identify which hand
+            
+        Returns:
+            np.ndarray: Joint angles for the hand
+        """
+        # Create array of zeros with length matching number of joint names
+        hand_joints = np.zeros(len(self._hand_joint_names))
+        
+        # Simple mapping from OpenXR hand joints to H1_2 hand joints
+        # This is a simplified implementation - you may need to adjust based on actual H1_2 hand structure
+        
+        # Map finger joints (simplified)
+        finger_mappings = {
+            "thumb": ["thumb_tip", "thumb_ip", "thumb_mcp"],
+            "index": ["index_tip", "index_dip", "index_pip", "index_mcp"],
+            "middle": ["middle_tip", "middle_dip", "middle_pip", "middle_mcp"],
+            "ring": ["ring_tip", "ring_dip", "ring_pip", "ring_mcp"],
+            "pinky": ["pinky_tip", "pinky_dip", "pinky_pip", "pinky_mcp"]
+        }
+        
+        # Calculate joint angles based on finger positions
+        for finger_name, joint_names in finger_mappings.items():
+            if finger_name in self._hand_joint_names:
+                # Simple angle calculation based on finger tip position relative to wrist
+                if "tip" in joint_names[0] and joint_names[0] in hand_poses:
+                    tip_pos = hand_poses[joint_names[0]][:3]
+                    wrist_pos = hand_poses["wrist"][:3]
+                    
+                    # Calculate angle based on distance from wrist
+                    distance = np.linalg.norm(tip_pos - wrist_pos)
+                    # Normalize to reasonable joint angle range
+                    angle = np.clip(distance * 2.0, 0.0, 1.0)  # Scale factor may need adjustment
+                    
+                    joint_idx = self._hand_joint_names.index(finger_name)
+                    hand_joints[joint_idx] = angle
+        
+        return hand_joints
+
+    def _process_arm_joints(self, wrist_pose: np.ndarray, arm_side: str) -> np.ndarray:
+        """Process wrist pose to generate arm joint angles using simplified IK.
+        
+        Args:
+            wrist_pose: Wrist pose from OpenXR
+            arm_side: "left" or "right" to identify which arm
+            
+        Returns:
+            np.ndarray: Joint angles for the arm
+        """
+        # Create array of zeros with length matching number of arm joint names
+        arm_joints = np.zeros(len(self._arm_joint_names))
+        
+        # Extract wrist position and orientation
+        wrist_pos = wrist_pose[:3]
+        wrist_quat = wrist_pose[3:]
+        
+        # Simple IK calculation for arm joints
+        # This is a simplified implementation - you may need more sophisticated IK
+        
+        # Calculate shoulder and elbow angles based on wrist position
+        # Assuming a simple 2-link arm model (shoulder to elbow, elbow to wrist)
+        
+        # Base position (shoulder position - you may need to adjust this)
+        base_pos = np.array([0.0, 0.0, 1.0])  # Approximate shoulder position
+        
+        # Vector from base to wrist
+        target_vector = wrist_pos - base_pos
+        
+        # Simple angle calculations (this is very simplified)
+        # You may need to implement proper IK solver here
+        
+        # Shoulder pitch (rotation around Y axis)
+        shoulder_pitch = np.arctan2(target_vector[2], target_vector[0])
+        
+        # Shoulder roll (rotation around X axis)
+        shoulder_roll = np.arctan2(target_vector[1], np.sqrt(target_vector[0]**2 + target_vector[2]**2))
+        
+        # Elbow angle (simplified)
+        elbow_angle = np.pi / 4  # 45 degrees as default
+        
+        # Map to actual joint names
+        if "shoulder_pitch" in self._arm_joint_names:
+            idx = self._arm_joint_names.index("shoulder_pitch")
+            arm_joints[idx] = shoulder_pitch
+            
+        if "shoulder_roll" in self._arm_joint_names:
+            idx = self._arm_joint_names.index("shoulder_roll")
+            arm_joints[idx] = shoulder_roll
+            
+        if "elbow" in self._arm_joint_names:
+            idx = self._arm_joint_names.index("elbow")
+            arm_joints[idx] = elbow_angle
+        
+        return arm_joints
+
+    def _retarget_abs(self, wrist: np.ndarray) -> np.ndarray:
+        """Handle absolute pose retargeting.
+
+        Args:
+            wrist: Wrist pose data from OpenXR
+
+        Returns:
+            Retargeted wrist pose in USD control frame
+        """
+        # Convert wrist data in openxr frame to usd control frame
+        # Similar to GR1T2 implementation but may need adjustments for H1_2
+
+        # Create pose object for openxr_right_wrist_in_world
+        wrist_pos = torch.tensor(wrist[:3], dtype=torch.float32)
+        wrist_quat = torch.tensor(wrist[3:], dtype=torch.float32)
+        openxr_right_wrist_in_world = PoseUtils.make_pose(wrist_pos, PoseUtils.matrix_from_quat(wrist_quat))
+
+        # The usd control frame transformation for H1_2
+        # This may need adjustment based on H1_2's coordinate system
+        zero_pos = torch.zeros(3, dtype=torch.float32)
+        # Adjust rotation as needed for H1_2
+        z_axis_rot_quat = torch.tensor([0, 0, 0, 1], dtype=torch.float32)
+        usd_right_roll_link_in_openxr_right_wrist = PoseUtils.make_pose(
+            zero_pos, PoseUtils.matrix_from_quat(z_axis_rot_quat)
+        )
+
+        # Convert wrist pose in openxr frame to usd control frame
+        usd_right_roll_link_in_world = PoseUtils.pose_in_A_to_pose_in_B(
+            usd_right_roll_link_in_openxr_right_wrist, openxr_right_wrist_in_world
+        )
+
+        # extract position and rotation
+        usd_right_roll_link_in_world_pos, usd_right_roll_link_in_world_mat = PoseUtils.unmake_pose(
+            usd_right_roll_link_in_world
+        )
+        usd_right_roll_link_in_world_quat = PoseUtils.quat_from_matrix(usd_right_roll_link_in_world_mat)
+
+        return np.concatenate([usd_right_roll_link_in_world_pos, usd_right_roll_link_in_world_quat])

--- a/source/isaaclab/isaaclab/devices/teleop_device_factory.py
+++ b/source/isaaclab/isaaclab/devices/teleop_device_factory.py
@@ -17,6 +17,8 @@ from isaaclab.devices.keyboard import Se2Keyboard, Se2KeyboardCfg, Se3Keyboard, 
 from isaaclab.devices.openxr.retargeters import (
     GR1T2Retargeter,
     GR1T2RetargeterCfg,
+    H1_2Retargeter,
+    H1_2RetargeterCfg,
     GripperRetargeter,
     GripperRetargeterCfg,
     Se3AbsRetargeter,
@@ -49,6 +51,7 @@ RETARGETER_MAP: dict[type[RetargeterCfg], type[RetargeterBase]] = {
     Se3RelRetargeterCfg: Se3RelRetargeter,
     GripperRetargeterCfg: GripperRetargeter,
     GR1T2RetargeterCfg: GR1T2Retargeter,
+    H1_2RetargeterCfg: H1_2Retargeter,
 }
 
 

--- a/source/isaaclab_assets/isaaclab_assets/robots/unitree.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/unitree.py
@@ -12,6 +12,8 @@ The following configurations are available:
 * :obj:`UNITREE_GO2_CFG`: Unitree Go2 robot with DC motor model for the legs
 * :obj:`H1_CFG`: H1 humanoid robot
 * :obj:`H1_MINIMAL_CFG`: H1 humanoid robot with minimal collision bodies
+* :obj:`H1_2_CFG`: H1_2 humanoid robot
+* :obj:`H1_2_MINIMAL_CFG`: H1_2 humanoid robot with minimal collision bodies
 * :obj:`G1_CFG`: G1 humanoid robot
 * :obj:`G1_MINIMAL_CFG`: G1 humanoid robot with minimal collision bodies
 
@@ -262,6 +264,102 @@ H1_CFG = ArticulationCfg(
 H1_MINIMAL_CFG = H1_CFG.copy()
 H1_MINIMAL_CFG.spawn.usd_path = f"{ISAACLAB_NUCLEUS_DIR}/Robots/Unitree/H1/h1_minimal.usd"
 """Configuration for the Unitree H1 Humanoid robot with fewer collision meshes.
+
+This configuration removes most collision meshes to speed up simulation.
+"""
+
+
+H1_2_CFG = ArticulationCfg(
+    spawn=sim_utils.UsdFileCfg(
+        usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/Unitree/H1_2/h1_2.usd",
+        activate_contact_sensors=True,
+        rigid_props=sim_utils.RigidBodyPropertiesCfg(
+            disable_gravity=False,
+            retain_accelerations=False,
+            linear_damping=0.0,
+            angular_damping=0.0,
+            max_linear_velocity=1000.0,
+            max_angular_velocity=1000.0,
+            max_depenetration_velocity=1.0,
+        ),
+        articulation_props=sim_utils.ArticulationRootPropertiesCfg(
+            enabled_self_collisions=False, solver_position_iteration_count=4, solver_velocity_iteration_count=4
+        ),
+    ),
+    init_state=ArticulationCfg.InitialStateCfg(
+        pos=(0.0, 0.0, 1.05),
+        joint_pos={
+            ".*_hip_yaw": 0.0,
+            ".*_hip_roll": 0.0,
+            ".*_hip_pitch": -0.28,  # -16 degrees
+            ".*_knee": 0.79,  # 45 degrees
+            ".*_ankle": -0.52,  # -30 degrees
+            "torso": 0.0,
+            ".*_shoulder_pitch": 0.28,
+            ".*_shoulder_roll": 0.0,
+            ".*_shoulder_yaw": 0.0,
+            ".*_elbow": 0.52,
+            # Add H1_2 specific hand joints here
+            ".*_hand_joint": 0.0,
+        },
+        joint_vel={".*": 0.0},
+    ),
+    soft_joint_pos_limit_factor=0.9,
+    actuators={
+        "legs": ImplicitActuatorCfg(
+            joint_names_expr=[".*_hip_yaw", ".*_hip_roll", ".*_hip_pitch", ".*_knee", "torso"],
+            effort_limit_sim=300,
+            stiffness={
+                ".*_hip_yaw": 150.0,
+                ".*_hip_roll": 150.0,
+                ".*_hip_pitch": 200.0,
+                ".*_knee": 200.0,
+                "torso": 200.0,
+            },
+            damping={
+                ".*_hip_yaw": 5.0,
+                ".*_hip_roll": 5.0,
+                ".*_hip_pitch": 5.0,
+                ".*_knee": 5.0,
+                "torso": 5.0,
+            },
+        ),
+        "feet": ImplicitActuatorCfg(
+            joint_names_expr=[".*_ankle"],
+            effort_limit_sim=100,
+            stiffness={".*_ankle": 20.0},
+            damping={".*_ankle": 4.0},
+        ),
+        "arms": ImplicitActuatorCfg(
+            joint_names_expr=[".*_shoulder_pitch", ".*_shoulder_roll", ".*_shoulder_yaw", ".*_elbow"],
+            effort_limit_sim=300,
+            stiffness={
+                ".*_shoulder_pitch": 40.0,
+                ".*_shoulder_roll": 40.0,
+                ".*_shoulder_yaw": 40.0,
+                ".*_elbow": 40.0,
+            },
+            damping={
+                ".*_shoulder_pitch": 10.0,
+                ".*_shoulder_roll": 10.0,
+                ".*_shoulder_yaw": 10.0,
+                ".*_elbow": 10.0,
+            },
+        ),
+        "hands": ImplicitActuatorCfg(
+            joint_names_expr=[".*_hand_joint"],
+            effort_limit_sim=50,
+            stiffness={".*_hand_joint": 20.0},
+            damping={".*_hand_joint": 2.0},
+        ),
+    },
+)
+"""Configuration for the Unitree H1_2 Humanoid robot."""
+
+
+H1_2_MINIMAL_CFG = H1_2_CFG.copy()
+H1_2_MINIMAL_CFG.spawn.usd_path = f"{ISAACLAB_NUCLEUS_DIR}/Robots/Unitree/H1_2/h1_2_minimal.usd"
+"""Configuration for the Unitree H1_2 Humanoid robot with fewer collision meshes.
 
 This configuration removes most collision meshes to speed up simulation.
 """

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/__init__.py
@@ -6,7 +6,7 @@
 import gymnasium as gym
 import os
 
-from . import agents, exhaustpipe_gr1t2_pink_ik_env_cfg, nutpour_gr1t2_pink_ik_env_cfg, pickplace_gr1t2_env_cfg
+from . import agents, exhaustpipe_gr1t2_pink_ik_env_cfg, nutpour_gr1t2_pink_ik_env_cfg, pickplace_gr1t2_env_cfg, pickplace_h1_2_env_cfg
 
 gym.register(
     id="Isaac-PickPlace-GR1T2-Abs-v0",
@@ -34,6 +34,16 @@ gym.register(
     kwargs={
         "env_cfg_entry_point": exhaustpipe_gr1t2_pink_ik_env_cfg.ExhaustPipeGR1T2PinkIKEnvCfg,
         "robomimic_bc_cfg_entry_point": os.path.join(agents.__path__[0], "robomimic/bc_rnn_image_exhaust_pipe.json"),
+    },
+    disable_env_checker=True,
+)
+
+gym.register(
+    id="Isaac-PickPlace-H1_2-Abs-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    kwargs={
+        "env_cfg_entry_point": pickplace_h1_2_env_cfg.PickPlaceH1_2EnvCfg,
+        "robomimic_bc_cfg_entry_point": os.path.join(agents.__path__[0], "robomimic/bc_rnn_low_dim.json"),
     },
     disable_env_checker=True,
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/pickplace_h1_2_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/pickplace_h1_2_env_cfg.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Configuration for the H1_2 pick and place environment."""
+
+from isaaclab_assets.robots.unitree import H1_2_MINIMAL_CFG
+from isaaclab.devices import DevicesCfg, OpenXRDeviceCfg
+from isaaclab.devices.openxr.retargeters import H1_2RetargeterCfg
+from isaaclab_tasks.manager_based.manipulation.pick_place.pickplace_base_env_cfg import PickPlaceBaseEnvCfg
+from isaaclab.utils import configclass
+
+
+@configclass
+class PickPlaceH1_2EnvCfg(PickPlaceBaseEnvCfg):
+    """Configuration for the H1_2 environment."""
+
+    def __post_init__(self):
+        """Post initialization."""
+        # general settings
+        self.decimation = 6
+        self.episode_length_s = 20.0
+        # simulation settings
+        self.sim.dt = 1 / 120  # 120Hz
+        self.sim.render_interval = 2
+
+        # Set the robot to H1_2
+        self.scene.robot = H1_2_MINIMAL_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
+
+        # Configure teleop devices for H1_2
+        self.teleop_devices = DevicesCfg(
+            devices={
+                "handtracking": OpenXRDeviceCfg(
+                    retargeters=[
+                        H1_2RetargeterCfg(
+                            enable_visualization=True,
+                            # OpenXR hand tracking has 26 joints per hand
+                            num_open_xr_hand_joints=2 * 26,
+                            sim_device=self.sim.device,
+                            # Define H1_2 specific joint names
+                            hand_joint_names=[
+                                "left_hand_joint",
+                                "right_hand_joint",
+                                # Add more specific hand joint names as needed
+                            ],
+                            arm_joint_names=[
+                                "left_shoulder_pitch",
+                                "left_shoulder_roll", 
+                                "left_shoulder_yaw",
+                                "left_elbow",
+                                "right_shoulder_pitch",
+                                "right_shoulder_roll",
+                                "right_shoulder_yaw", 
+                                "right_elbow",
+                            ],
+                        ),
+                    ],
+                    sim_device=self.sim.device,
+                    xr_cfg=self.xr,
+                ),
+            }
+        )
+
+        # Configure actions for H1_2
+        # You may need to adjust this based on H1_2's actual action space
+        self.actions.pink_ik_cfg.hand_joint_names = [
+            "left_hand_joint",
+            "right_hand_joint",
+        ]
+        
+        # Set action space dimensions based on H1_2
+        # This should match the output of the H1_2Retargeter
+        # 7 (left wrist) + 7 (right wrist) + hand_joints + arm_joints
+        self.actions.pink_ik_cfg.action_space = 14 + len(self.actions.pink_ik_cfg.hand_joint_names) + 8  # 8 arm joints


### PR DESCRIPTION
- Introduced H1_2Retargeter and H1_2RetargeterCfg in the teleop_device_factory and retargeters module.
- Added H1_2_CFG and H1_2_MINIMAL_CFG configurations for the H1_2 humanoid robot in unitree.py.
- Registered a new pick-and-place environment for the H1_2 robot in the task manager.

These changes enhance the support for the H1_2 humanoid robot in the simulation environment.

# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html
-->

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
